### PR TITLE
Change repository schema to allow plugin versions

### DIFF
--- a/v1/repository-schema.json
+++ b/v1/repository-schema.json
@@ -66,14 +66,7 @@
       }
     },
     "RepositoryPluginVersionListItem": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/RepositoryPluginVersionListItemInline"
-        },
-        {
-          "$ref": "#/definitions/RepositoryPluginVersionListItemExternal"
-        }
-      ]
+      "$ref": "#/definitions/RepositoryPluginVersionListItemExternal"
     },
     "RepositoryPluginVersionListItemExternal": {
       "$comment": "Definition of a downloadable plugin version and it's requirements",
@@ -117,40 +110,6 @@
         "requirements",
         "url",
         "checksum"
-      ]
-    },
-    "RepositoryPluginVersionListItemInline": {
-      "$comment": "Definition of an inline plugin version and its requirements",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "type": "string",
-          "const": "php-inline"
-        },
-        "api-version": {
-          "$comment": "API version used in this plugin",
-          "type": "string",
-          "const": "1.0.0"
-        },
-        "version": {
-          "$comment": "Version of the plugin",
-          "type": "string",
-          "$ref": "#/definitions/VersionExpression"
-        },
-        "requirements": {
-          "$ref": "#/definitions/RepositoryPluginVersionListItemRequirements"
-        },
-        "code": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "type",
-        "api-version",
-        "version",
-        "requirements",
-        "code"
       ]
     },
     "RepositoryPluginVersionListItemRequirements":{

--- a/v1/repository-schema.json
+++ b/v1/repository-schema.json
@@ -42,7 +42,11 @@
         "checksum": {
           "$ref": "#/definitions/HashChecksum"
         }
-      }
+      },
+      "required": [
+        "url",
+        "checksum"
+      ]
     },
     "RepositoryPluginList": {
       "type": "object",
@@ -111,7 +115,8 @@
         "api-version",
         "version",
         "requirements",
-        "url"
+        "url",
+        "checksum"
       ]
     },
     "RepositoryPluginVersionListItemInline": {

--- a/v1/repository-schema.json
+++ b/v1/repository-schema.json
@@ -1,182 +1,281 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "id": "https://phpcq.github.io/schema/v1/repository-schema.json#",
+  "$id": "https://phpcq.github.io/schema/v1/repository-schema.json",
   "title": "phpcq repository schema",
-  "$ref": "#/definitions/Repository",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/Repository"
+    }
+  ],
   "definitions": {
     "Repository": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "bootstraps": {
-          "$ref": "#/definitions/BootstrapList"
+        "includes": {
+          "$ref": "#/definitions/RepositoryIncludes"
         },
-        "phars": {
-          "$ref": "#/definitions/PharProgramList"
+        "plugins": {
+          "$ref": "#/definitions/RepositoryPluginList"
+        },
+        "tools": {
+          "$ref": "#/definitions/RepositoryToolList"
         }
-      },
-      "required": ["phars"]
-    },
-    "BootstrapList": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-zA-Z0-9-]*$": {
-          "description": "Name of a bootstrap file.",
-          "oneOf": [
-            {
-              "$comment": "An inline bootstrap file.",
-              "$ref": "#/definitions/BootstrapTypeInline"
-            },
-            {
-              "$comment": "A bootstrap file.",
-              "$ref": "#/definitions/BootstrapTypeFile"
-            }
-          ]
-        }
-      },
-      "additionalProperties": false
-    },
-    "BootstrapType": {
-      "oneOf": [
-        {
-          "$comment": "An inline bootstrap file.",
-          "$ref": "#/definitions/BootstrapTypeInline"
-        },
-        {
-          "$comment": "A bootstrap file.",
-          "$ref": "#/definitions/BootstrapTypeFile"
-        },
-        {
-          "type": "string",
-          "$comment": "name of a bootstrap in /bootstrap"
-        }
-      ]
-    },
-    "BootstrapTypeInline": {
-      "$comment": "An inline bootstrap file.",
-      "type": "object",
-      "properties": {
-        "type": {
-          "const": "inline"
-        },
-        "code": {
-          "$comment": "The PHP code of the bootstrap.",
-          "type": "string",
-          "contentMediaType": "application/x-php"
-        },
-        "plugin-version": {
-          "$comment": "Version of the plugin contained",
-          "type": "string"
-        }
-      },
-      "required": ["type", "code", "plugin-version"],
-      "additionalProperties": false
-    },
-    "BootstrapTypeFile": {
-      "$comment": "A bootstrap file.",
-      "type": "object",
-      "properties": {
-        "type": {
-          "const": "file"
-        },
-        "url": {
-          "$comment": "URL of a bootstrap file",
-          "type": "string",
-          "format": "iri-reference"
-        },
-        "plugin-version": {
-          "$comment": "Version of the plugin contained",
-          "type": "string",
-          "pattern": "^v?(\\d++)(?:\\.(\\d++))?(?:\\.(\\d++))?(?:\\.(\\d++))?[._-]?(?:(stable|beta|b|RC|alpha|a|patch|pl|p)((?:[.-]?\\d+)*+)?)?([.-]?dev)?(?:\\+[^\\s]+)?$"
-        }
-      },
-      "required": ["type", "url", "plugin-version"],
-      "additionalProperties": false
-    },
-    "PharProgramList": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-zA-Z0-9-]*$": {
-          "description": "The list of contained phar program sources.",
-          "$ref": "#/definitions/PharProgramSource"
-        }
-      },
-      "additionalProperties": false
-    },
-    "PharProgramSource": {
-      "description": "A program source may be either an IRI to an version include file or a program version list",
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "url": {
-              "$comment": "URL of an repository include file",
-              "type": "string",
-              "format": "iri-reference"
-            },
-            "checksum": {
-              "$ref": "#/definitions/HashChecksum"
-            }
-          }
-        },
-        {
-          "$ref": "#/definitions/PharProgramVersionList"
-        }
-      ]
-    },
-    "PharProgramVersionList": {
-      "$comment": "Definition of a phar program and it's sources",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/PharProgramVersion"
       }
     },
-    "PharProgramVersion": {
-      "$comment": "Definition of a phar program version and it's requirements",
+    "RepositoryIncludes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/RepositoryInclude"
+      }
+    },
+    "RepositoryInclude": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
-        "version": {
-          "type": "string",
-          "pattern": "^v?(\\d++)(?:\\.(\\d++))?(?:\\.(\\d++))?(?:\\.(\\d++))?[._-]?(?:(stable|beta|b|RC|alpha|a|patch|pl|p)((?:[.-]?\\d+)*+)?)?([.-]?dev)?(?:\\+[^\\s]+)?$"
-        },
-        "phar-url": {
-          "$comment": "URL to the .phar file",
+        "url": {
+          "$comment": "URL of an include file",
           "type": "string",
           "format": "iri-reference"
         },
-        "bootstrap": {
-          "$ref": "#/definitions/BootstrapType"
+        "checksum": {
+          "$ref": "#/definitions/HashChecksum"
+        }
+      }
+    },
+    "RepositoryPluginList": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-zA-Z0-9-]*$": {
+          "description": "List of versions per plugin.",
+          "$ref": "#/definitions/RepositoryPluginVersionList"
+        }
+      }
+    },
+    "RepositoryPluginVersionList": {
+      "$comment": "Definition of plugin versions",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/RepositoryPluginVersionListItem"
+      }
+    },
+    "RepositoryPluginVersionListItem": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/RepositoryPluginVersionListItemInline"
+        },
+        {
+          "$ref": "#/definitions/RepositoryPluginVersionListItemExternal"
+        }
+      ]
+    },
+    "RepositoryPluginVersionListItemExternal": {
+      "$comment": "Definition of a downloadable plugin version and it's requirements",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "php-file"
+        },
+        "api-version": {
+          "$comment": "API version used in this plugin",
+          "type": "string",
+          "const": "1.0.0"
+        },
+        "version": {
+          "$comment": "Version of the plugin",
+          "$ref": "#/definitions/VersionExpression"
         },
         "requirements": {
-          "$ref": "#/definitions/PharPlatformRequirements"
+          "$ref": "#/definitions/RepositoryPluginVersionListItemRequirements"
         },
-        "hash": {
+        "url": {
+          "$comment": "URL to the plugin file",
+          "type": "string",
+          "format": "iri-reference"
+        },
+        "checksum": {
           "$ref": "#/definitions/HashChecksum"
         },
         "signature": {
-          "$comment": "URL to the .phar.asc file",
+          "$comment": "URL to the .asc file",
           "type": "string",
           "format": "iri-reference"
         }
       },
-      "required": ["version", "phar-url", "bootstrap", "requirements"],
-      "additionalProperties": false
+      "required": [
+        "type",
+        "api-version",
+        "version",
+        "requirements",
+        "url"
+      ]
     },
-    "PharPlatformRequirements": {
+    "RepositoryPluginVersionListItemInline": {
+      "$comment": "Definition of an inline plugin version and its requirements",
       "type": "object",
-      "patternProperties": {
-        "^(php|ext-[a-z0-9-]*)$": {
-          "description": "The list of platform requirements for phar programs.",
-          "$ref": "#/definitions/VersionConstraint"
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "php-inline"
+        },
+        "api-version": {
+          "$comment": "API version used in this plugin",
+          "type": "string",
+          "const": "1.0.0"
+        },
+        "version": {
+          "$comment": "Version of the plugin",
+          "type": "string",
+          "$ref": "#/definitions/VersionExpression"
+        },
+        "requirements": {
+          "$ref": "#/definitions/RepositoryPluginVersionListItemRequirements"
+        },
+        "code": {
+          "type": "string"
         }
       },
-      "additionalProperties": false
+      "required": [
+        "type",
+        "api-version",
+        "version",
+        "requirements",
+        "code"
+      ]
+    },
+    "RepositoryPluginVersionListItemRequirements":{
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "php": {
+          "$ref": "#/definitions/PhpPlatformRequirements"
+        },
+        "tool": {
+          "$ref": "#/definitions/ToolRequirements"
+        },
+        "plugin": {
+          "$ref": "#/definitions/PluginRequirements"
+        },
+        "composer": {
+          "$ref": "#/definitions/ComposerRequirements"
+        }
+      }
+    },
+    "PhpPlatformRequirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^(php|ext-[a-z0-9-]*)$": {
+          "description": "Map of named php platform requirements.",
+          "$ref": "#/definitions/VersionConstraint"
+        }
+      }
+    },
+    "ToolRequirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-zA-Z0-9-]*$": {
+          "description": "A list of named tool requirements.",
+          "$ref": "#/definitions/VersionConstraint"
+        }
+      }
+    },
+    "PluginRequirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-zA-Z0-9-]*$": {
+          "description": "A list of named plugin requirements.",
+          "$ref": "#/definitions/VersionConstraint"
+        }
+      }
+    },
+    "ComposerRequirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-zA-Z0-9-]*/[a-zA-Z0-9-]*$": {
+          "description": "A list of named composer requirements.",
+          "$ref": "#/definitions/VersionConstraint"
+        }
+      }
+    },
+    "RepositoryToolList": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-zA-Z0-9-]*$": {
+          "description": "List of versions per plugin.",
+          "$ref": "#/definitions/RepositoryToolVersionList"
+        }
+      }
+    },
+    "RepositoryToolVersionList": {
+      "$comment": "Definition of tool versions",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/RepositoryToolVersionListItem"
+      }
+    },
+    "RepositoryToolVersionListItem": {
+      "$comment": "Definition of a tool version and it's requirements",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "version": {
+          "$comment": "Version of the plugin",
+          "$ref": "#/definitions/VersionExpression"
+        },
+        "requirements": {
+          "$ref": "#/definitions/RepositoryToolVersionListItemRequirements"
+        },
+        "url": {
+          "$comment": "URL to the plugin file",
+          "type": "string",
+          "format": "iri-reference"
+        },
+        "checksum": {
+          "$ref": "#/definitions/HashChecksum"
+        },
+        "signature": {
+          "$comment": "URL to the .asc file",
+          "type": "string",
+          "format": "iri-reference"
+        }
+      },
+      "required": [
+        "version",
+        "requirements",
+        "url"
+      ]
+    },
+    "RepositoryToolVersionListItemRequirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "php": {
+          "$ref": "#/definitions/PhpPlatformRequirements"
+        },
+        "composer": {
+          "$ref": "#/definitions/ComposerRequirements"
+        }
+      }
+    },
+    "VersionExpression": {
+      "type": "string",
+      "pattern": "^v?(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?(?:\\.(\\d+))?[._-]?(?:(stable|beta|b|RC|alpha|a|patch|pl|p)((?:[.-]?\\d+)*)?)?([.-]?dev)?(?:\\+[^\\s]+)?$"
     },
     "VersionConstraint": {
       "oneOf": [
         {
           "$comment": "Allow multiple constraints chained by OR. ie. ^1.0.0( || ^2.0.0)?",
-          "pattern": "^(\\^|>=?)v?(\\d++)(?:\\.(\\d++))?(?:\\.(\\d++))?(?:\\.(\\d++))?[._-]?(?:(stable|beta|b|RC|alpha|a|patch|pl|p)((?:[.-]?\\d+)*+)?)?([.-]?dev)?(?:\\+[^\\s]+)?(\\s?\\|\\|\\s(\\^|>=?)v?(\\d++)(?:\\.(\\d++))?(?:\\.(\\d++))?(?:\\.(\\d++))?[._-]?(?:(stable|beta|b|RC|alpha|a|patch|pl|p)((?:[.-]?\\d+)*+)?)?([.-]?dev)?(?:\\+[^\\s]+)?)*$"
+          "pattern": "^(\\^|>=?)v?(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?(?:\\.(\\d+))?[._-]?(?:(stable|beta|b|RC|alpha|a|patch|pl|p)((?:[.-]?\\d+)*)?)?([.-]?dev)?(?:\\+[^\\s]+)?(\\s?\\|\\|\\s(\\^|>=?)v?(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?(?:\\.(\\d+))?[._-]?(?:(stable|beta|b|RC|alpha|a|patch|pl|p)((?:[.-]?\\d+)*)?)?([.-]?dev)?(?:\\+[^\\s]+)?)*$"
         },
         {
           "$comment": "Unrestricted boundaries.",
@@ -187,65 +286,89 @@
     "HashChecksum": {
       "oneOf": [
         {
-          "$comment": "SHA 1",
-          "type": "object",
-          "properties": {
-            "type": {
-              "const": "sha-1"
-            },
-            "value": {
-              "type": "string",
-              "pattern": "^[a-z0-9]{40}$"
-            }
-          },
-          "required": ["type", "value"],
-          "additionalProperties": false
-        },
-     {
-          "$comment": "SHA 256",
-          "type": "object",
-          "properties": {
-            "type": {
-              "const": "sha-256"
-            },
-            "value": {
-              "type": "string",
-              "pattern": "^[a-z0-9]{64}$"
-            }
-          },
-          "required": ["type", "value"],
-          "additionalProperties": false
+          "$ref": "#/definitions/HashChecksumSHA1"
         },
         {
-          "$comment": "SHA 384",
-          "type": "object",
-          "properties": {
-            "type": {
-              "const": "sha-384"
-            },
-            "value": {
-              "type": "string",
-              "pattern": "^[a-z0-9]{96}$"
-            }
-          },
-          "required": ["type", "value"],
-          "additionalProperties": false
+          "$ref": "#/definitions/HashChecksumSHA256"
         },
         {
-          "$comment": "SHA 512",
-          "type": "object",
-          "properties": {
-            "type": {
-              "const": "sha-512"
-            },
-            "value": {
-              "type": "string",
-              "pattern": "^[a-z0-9]{128}$"
-            }
-          },
-          "required": ["type", "value"],
-          "additionalProperties": false
+          "$ref": "#/definitions/HashChecksumSHA384"
+        },
+        {
+          "$ref": "#/definitions/HashChecksumSHA512"
         }
+      ]
+    },
+    "HashChecksumSHA1": {
+      "$comment": "SHA 1",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "const": "sha-1"
+        },
+        "value": {
+          "type": "string",
+          "pattern": "^[a-z0-9]{40}$"
+        }
+      },
+      "required": [
+        "type",
+        "value"
+      ]
+    },
+    "HashChecksumSHA256": {
+      "$comment": "SHA 256",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "const": "sha-256"
+        },
+        "value": {
+          "type": "string",
+          "pattern": "^[a-z0-9]{64}$"
+        }
+      },
+      "required": [
+        "type",
+        "value"
+      ]
+    },
+    "HashChecksumSHA384": {
+      "$comment": "SHA 384",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "const": "sha-384"
+        },
+        "value": {
+          "type": "string",
+          "pattern": "^[a-z0-9]{96}$"
+        }
+      },
+      "required": [
+        "type",
+        "value"
+      ]
+    },
+    "HashChecksumSHA512": {
+      "$comment": "SHA 512",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "const": "sha-512"
+        },
+        "value": {
+          "type": "string",
+          "pattern": "^[a-z0-9]{128}$"
+        }
+      },
+      "required": [
+        "type",
+        "value"
       ]
     }
   }

--- a/v1/task-report.xsd
+++ b/v1/task-report.xsd
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema targetNamespace="https://phpcq.github.io/schema/v1/tool-report.xsd"
-           xmlns:tns="https://phpcq.github.io/schema/v1/tool-report.xsd"
+<xs:schema targetNamespace="https://phpcq.github.io/schema/v1/task-report.xsd"
+           xmlns:tns="https://phpcq.github.io/schema/v1/task-report.xsd"
            elementFormDefault="qualified"
            xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
-  <xs:element name="tool-report" type="tns:reportFile">
+  <xs:element name="task-report" type="tns:reportFile">
     <xs:annotation>
       <xs:documentation>
         The root element for reports.
@@ -14,7 +14,7 @@
 
   <xs:complexType name="reportFile">
     <xs:sequence>
-      <xs:element name="tools" type="tns:toolListType">
+      <xs:element name="tasks" type="tns:taskListType">
       </xs:element>
     </xs:sequence>
     <xs:attribute name="status" type="tns:reportStatusType" use="required"/>
@@ -47,16 +47,16 @@
     </xs:restriction>
   </xs:simpleType>
 
-  <xs:complexType name="toolListType">
+  <xs:complexType name="taskListType">
     <xs:annotation>
       <xs:documentation>
-        The list of all tool reports.
+        The list of all task reports.
       </xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:element name="tool" minOccurs="0" maxOccurs="unbounded" type="tns:toolReportType">
+      <xs:element name="task" minOccurs="0" maxOccurs="unbounded" type="tns:taskReportType">
         <!-- FIXME: unique condition does somehow not work out... :/ -->
-        <xs:unique name="unique_tool">
+        <xs:unique name="unique_task">
           <xs:selector xpath="."/>
           <xs:field xpath="@tns:name"/>
         </xs:unique>
@@ -64,34 +64,34 @@
     </xs:sequence>
   </xs:complexType>
 
-  <xs:complexType name="toolReportType">
+  <xs:complexType name="taskReportType">
     <xs:annotation>
       <xs:documentation>
-        Report information of a single tool.
+        Report information of a single task.
       </xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:element name="diagnostics" type="tns:toolDiagnosticListType"/>
-      <xs:element name="attachments" type="tns:toolAttachmentListType" minOccurs="0"/>
-      <xs:element name="diffs" type="tns:toolDiffListType" minOccurs="0"/>
+      <xs:element name="diagnostics" type="tns:taskDiagnosticListType"/>
+      <xs:element name="attachments" type="tns:taskAttachmentListType" minOccurs="0"/>
+      <xs:element name="diffs" type="tns:taskDiffListType" minOccurs="0"/>
     </xs:sequence>
     <xs:attribute name="name" type="tns:nonEmptyStringType">
       <xs:annotation>
-        <xs:documentation>The name of the executed tool</xs:documentation>
+        <xs:documentation>The name of the executed task</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="status" type="tns:toolStatusType"/>
+    <xs:attribute name="status" type="tns:taskStatusType"/>
     <xs:attribute name="version" type="xs:string" use="required">
       <xs:annotation>
-        <xs:documentation>The tool version</xs:documentation>
+        <xs:documentation>The task version</xs:documentation>
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>
 
-  <xs:simpleType name="toolStatusType">
+  <xs:simpleType name="taskStatusType">
     <xs:annotation>
       <xs:documentation>
-        The exit status of the tool execution. Either "passed" or "failed".
+        The exit status of the task execution. Either "passed" or "failed".
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
@@ -100,21 +100,21 @@
     </xs:restriction>
   </xs:simpleType>
 
-  <xs:complexType name="toolDiagnosticListType">
+  <xs:complexType name="taskDiagnosticListType">
     <xs:annotation>
       <xs:documentation>
-        The found diagnostics by the tool.
+        The found diagnostics by the task.
       </xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:element name="diagnostic" type="tns:toolDiagnosticType" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="diagnostic" type="tns:taskDiagnosticType" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
   </xs:complexType>
 
-  <xs:complexType name="toolDiagnosticType">
+  <xs:complexType name="taskDiagnosticType">
     <xs:annotation>
       <xs:documentation>
-        A diagnostic entry found by a tool.
+        A diagnostic entry found by a task.
       </xs:documentation>
     </xs:annotation>
     <xs:sequence>
@@ -190,12 +190,12 @@
         </xs:annotation>
       </xs:element>
     </xs:sequence>
-    <xs:attribute type="tns:toolDiagnosticSeverityType" name="severity" use="required"/>
+    <xs:attribute type="tns:taskDiagnosticSeverityType" name="severity" use="required"/>
     <xs:attribute type="tns:nonEmptyStringType" name="source"/>
     <xs:attribute type="tns:nonEmptyStringType" name="external_info_url"/>
   </xs:complexType>
 
-  <xs:simpleType name="toolDiagnosticSeverityType">
+  <xs:simpleType name="taskDiagnosticSeverityType">
     <xs:annotation>
       <xs:documentation>
         The severity of the diagnostic.
@@ -204,7 +204,7 @@
     <xs:restriction base="tns:nonEmptyStringType">
       <xs:enumeration value="none">
         <xs:annotation>
-          <xs:documentation>A non issue - strictly informational. (additional debug info requested like tool execution argument - only to be exported if threshold is set to none)</xs:documentation>
+          <xs:documentation>A non issue - strictly informational. (additional debug info requested like task execution argument - only to be exported if threshold is set to none)</xs:documentation>
         </xs:annotation>
       </xs:enumeration>
       <xs:enumeration value="info">
@@ -235,16 +235,16 @@
     </xs:restriction>
   </xs:simpleType>
 
-  <xs:complexType name="toolAttachmentListType">
+  <xs:complexType name="taskAttachmentListType">
     <xs:annotation>
-      <xs:documentation>The attachments produced by the tool.</xs:documentation>
+      <xs:documentation>The attachments produced by the task.</xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:element name="attachment" type="tns:toolAttachmentType" maxOccurs="unbounded" nillable="true"/>
+      <xs:element name="attachment" type="tns:taskAttachmentType" maxOccurs="unbounded" nillable="true"/>
     </xs:sequence>
   </xs:complexType>
 
-  <xs:complexType name="toolAttachmentType">
+  <xs:complexType name="taskAttachmentType">
     <xs:annotation>
       <xs:documentation>The attachment body</xs:documentation>
     </xs:annotation>
@@ -269,16 +269,16 @@
     </xs:simpleContent>
   </xs:complexType>
 
-  <xs:complexType name="toolDiffListType">
+  <xs:complexType name="taskDiffListType">
     <xs:annotation>
-      <xs:documentation>The diffs produced by the tool.</xs:documentation>
+      <xs:documentation>The diffs produced by the task.</xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:element name="diff" type="tns:toolDiffType" maxOccurs="unbounded" nillable="true"/>
+      <xs:element name="diff" type="tns:taskDiffType" maxOccurs="unbounded" nillable="true"/>
     </xs:sequence>
   </xs:complexType>
 
-  <xs:complexType name="toolDiffType">
+  <xs:complexType name="taskDiffType">
     <xs:annotation>
       <xs:documentation>The diff body</xs:documentation>
     </xs:annotation>


### PR DESCRIPTION
See phpcq/phpcq#48

Bootstraps are now "plugins", "phars" are "tools" and we allow multiple plugin versions.
In additions requirements are also possible from plugins towards tools.
